### PR TITLE
Allow the ability to set a tag when publishing to npmjs 

### DIFF
--- a/npm-publish.js
+++ b/npm-publish.js
@@ -17,9 +17,18 @@ const argv = yargs
                 onError("Publish to npm failed - Invalid path directory")
             }
             console.log('Current directory: ' + process.cwd());
+
+            publishOptions = {};
+            if(argv.tag)
+                publishOptions.tag = argv.tag
+
             npm.setAuthToken()
-                .then(npm.publish())
+                .then(npm.publish(publishOptions))
                 .catch(onError);
+    })
+    .option('tag', {
+        alias: 't',
+        describe: 'optional tag to add to your npm package. npmjs.com default to \'latest\'',
     })
     .argv;
 
@@ -27,4 +36,3 @@ function onError (err) {
   console.error(err);
   process.exit(-1);
 }
-


### PR DESCRIPTION
Be default npmjs.com will set a new package to latest unless you push with a different tag. It's useful to be able to push a custom tag if you like.